### PR TITLE
Don't fail setup if 'main' exists

### DIFF
--- a/.github/actions/set-up-repo/action.yaml
+++ b/.github/actions/set-up-repo/action.yaml
@@ -15,9 +15,9 @@ runs:
 
     # Repo tooling expects a local branch called 'main' unless a base is given
     # to every command, so configure that since the default local name will be
-    # 'master'.
+    # 'master' unless 'main' is the current branch (post-submit).
     - name: Set up main branch
-      run: git branch main origin/main
+      run: git rev-parse --verify --quiet main || git branch main origin/main
       shell: bash
 
     - name: Set up repo tooling


### PR DESCRIPTION
The setup action fails in postsubmit because the branch checked out is 'main', so in that specific case 'main' already exists. This checks if the branch exists before creating it.