### PR TITLE
Fix label typo

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-'p: vactor_math':
+'p: vector_math':
   - changed-files:
     - any-glob-to-any-file:
       - packages/vector_math/**/*


### PR DESCRIPTION
Fixes a typo in the label auto-assigned to vector_math PRs.