### PR TITLE
[ci] Update release action config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: run release
       run: |
-        git config --global user.name ${{ secrets.USER_NAME }}
-        git config --global user.email ${{ secrets.USER_EMAIL }}
+        git config set --global user.name "${{ secrets.USER_NAME }}"
+        git config set --global user.email "${{ secrets.USER_EMAIL }}"
         dart pub global run flutter_plugin_tools publish --all-changed --base-sha=HEAD~ --skip-confirmation --remote=origin
       env: {PUB_CREDENTIALS: "${{ secrets.PUB_CREDENTIALS }}"}


### PR DESCRIPTION
Adjusts the `git config` command syntax to try to resolve the cryptic "error: no action specified" message we are getting when the action runs.

It's not clear why this is happening in this repo when the same syntax works in flutter/packages, but hopefully using this format will either fix it, or at least narrow down the problem.