### PR TITLE
[vector_math] Release 2.4.0

### DIFF
--- a/packages/vector_math/CHANGELOG.md
+++ b/packages/vector_math/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 2.4.0-wip
+## 2.4.0
 
-- Remove the deprecated `SimplexNoise` class.
-- Optimized the `identity` constructors on the `Matrix` classes.
-- Require Dart 3.10.0 or greater.
+- Removes the deprecated `SimplexNoise` class.
+- Optimizes the `identity` constructors on the `Matrix` classes.
+- Updates metadata to reflect the move from
+  [google/vector_math.dart](https://github.com/google/vector_math.dart)
+  to [flutter/core-packages](https://github.com/flutter/core-packages),
+  which is the new source of truth for this package.
+- Updates source and metadata to follow Flutter team package conventions and
+  analysis options.
+- Updates minimum supported SDK version to Dart 3.10.
 
 ## 2.3.0
 

--- a/packages/vector_math/pubspec.yaml
+++ b/packages/vector_math/pubspec.yaml
@@ -5,7 +5,7 @@ name: vector_math
 description: A vector math library for 2D and 3D applications, supporting 2D, 3D, and 4D matrices.
 repository: https://github.com/flutter/core-packages/tree/main/packages/vector_math
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_math%22
-version: 2.4.0-wip
+version: 2.4.0
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
At the time of import from https://github.com/google/vector_math.dart, which doesn't use our continuous release model, a 2.4.0 release had been prepped, but never actually finalized.

This updates the version to do the first release from the new location.

Although the removal of the long-deprecated API is technically a breaking change, it is being done as a minor version change for the reasons discussed in https://github.com/google/vector_math.dart/issues/269. Since the plan was to release as 2.4.0 when it was in the old location, this carries out that plan as intended.

Fixes https://github.com/google/vector_math.dart/issues/269

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter style guide] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[vector_math]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/core-packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter style guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
