### PR TITLE
[various] Publish imported packages

### DIFF
--- a/packages/flutter_template_images/CHANGELOG.md
+++ b/packages/flutter_template_images/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 5.0.1
 
+* Updates metadata for move to https://github.com/flutter/core-packages.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 5.0.0

--- a/packages/flutter_template_images/pubspec.yaml
+++ b/packages/flutter_template_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_template_images
 description: Image files for use in flutter_tools templates without adding binary files to flutter/flutter.
 repository: https://github.com/flutter/core-packages/tree/main/packages/flutter_template_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_template_images%22
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/multicast_dns/CHANGELOG.md
+++ b/packages/multicast_dns/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.3.3+1
 
+* Updates metadata for move to https://github.com/flutter/core-packages.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.3.3

--- a/packages/multicast_dns/pubspec.yaml
+++ b/packages/multicast_dns/pubspec.yaml
@@ -2,7 +2,7 @@ name: multicast_dns
 description: Dart package for performing mDNS queries (e.g. Bonjour, Avahi).
 repository: https://github.com/flutter/core-packages/tree/main/packages/multicast_dns
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+multicast_dns%22
-version: 0.3.3
+version: 0.3.3+1
 
 environment:
   sdk: ^3.10.0

--- a/packages/standard_message_codec/CHANGELOG.md
+++ b/packages/standard_message_codec/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.0.1+5
 
+* Updates metadata for move to https://github.com/flutter/core-packages.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.0.1+4

--- a/packages/standard_message_codec/pubspec.yaml
+++ b/packages/standard_message_codec/pubspec.yaml
@@ -1,8 +1,8 @@
 name: standard_message_codec
 description: An efficient and schemaless binary encoding format for Flutter and Dart.
-version: 0.0.1+4
 repository: https://github.com/flutter/core-packages/tree/main/packages/standard_message_codec
 issue_tracker:  https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Astandard_message_codec
+version: 0.0.1+5
 
 environment:
   sdk: ^3.10.0

--- a/third_party/packages/mustache_template/CHANGELOG.md
+++ b/third_party/packages/mustache_template/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.5
 
+* Updates metadata for move to https://github.com/flutter/core-packages.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.0.4

--- a/third_party/packages/mustache_template/pubspec.yaml
+++ b/third_party/packages/mustache_template/pubspec.yaml
@@ -2,7 +2,7 @@ name: mustache_template
 description: A templating library that implements the Mustache template specification
 repository: https://github.com/flutter/core-packages/tree/main/third_party/packages/mustache_template
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+mustache_template%22
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
https://github.com/flutter/core-packages/pull/18 was intended to bump versions to publish from the new locations, but I still had these changes locally, so they didn't publish. (Instead, they failed release because it tried to re-publish the existing versions.)

This adds the version bumps that were intended to be included in that PR.

Part of https://github.com/flutter/flutter/issues/185027