### PR TITLE
[vector_math] Document CircleGenerator API

### DIFF
--- a/packages/vector_math/CHANGELOG.md
+++ b/packages/vector_math/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+* Documents the public `CircleGenerator` API.
+
 ## 2.4.2
 
 * Documents the public geometry filter APIs.

--- a/packages/vector_math/lib/src/vector_math_geometry/generators/circle_generator.dart
+++ b/packages/vector_math/lib/src/vector_math_geometry/generators/circle_generator.dart
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): Remove this and fix violations. See
-//  https://github.com/flutter/flutter/issues/186827
-// ignore_for_file: public_member_api_docs
-
 part of '../../../vector_math_geometry.dart';
 
+/// Generates a flat, circular (or partial circle/pie-slice) mesh in the
+/// XZ plane, centered at the origin.
 class CircleGenerator extends GeometryGenerator {
   late double _radius;
   late int _segments;
@@ -20,6 +18,11 @@ class CircleGenerator extends GeometryGenerator {
   @override
   int get indexCount => _segments * 3;
 
+  /// Creates a circle mesh of the given [radius].
+  ///
+  /// [segments] controls how many triangles are used around the
+  /// circumference. [thetaStart] and [thetaLength] can be used to generate
+  /// only a slice of the circle, both given in radians.
   MeshGeometry createCircle(
     double radius, {
     GeometryGeneratorFlags? flags,

--- a/packages/vector_math/pubspec.yaml
+++ b/packages/vector_math/pubspec.yaml
@@ -5,7 +5,7 @@ name: vector_math
 description: A vector math library for 2D and 3D applications, supporting 2D, 3D, and 4D matrices.
 repository: https://github.com/flutter/core-packages/tree/main/packages/vector_math
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+vector_math%22
-version: 2.4.2
+version: 2.4.3
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Adds public API docs for `CircleGenerator` (class and `createCircle`) and removes the `public_member_api_docs` ignore for `circle_generator.dart`, following the same pattern as #12 and #22.

Part of the ongoing vector_math doc migration tracked in flutter/flutter#186827.

## Validation

- `dart analyze`
- `dart test` (252 tests)
- `dart pub global run flutter_plugin_tools validate --packages=vector_math`
- `dart pub global run flutter_plugin_tools format --packages=vector_math --fail-on-change --no-swift`
- `dart pub global run flutter_plugin_tools publish-check --packages=vector_math --allow-pre-release`

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

No new tests were added because the implementation diff only changes documentation comments. The complete existing package test suite passes.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
