### PR TITLE
[mustache_template] Adopt code-excerpts for README

### DIFF
--- a/third_party/packages/mustache_template/CHANGELOG.md
+++ b/third_party/packages/mustache_template/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.6
+
+* Adopts `code-excerpt` for the README's Dart snippets so they're validated
+  against compilable, analyzed source (fixes an invalid snippet and a
+  copy-pasted duplicate example that had gone unnoticed).
+* Removes the `exempt_from_excerpts` CI opt-out now that the README is
+  excerpt-backed.
+
 ## 2.0.5
 
 * Updates metadata for move to https://github.com/flutter/core-packages.

--- a/third_party/packages/mustache_template/CHANGELOG.md
+++ b/third_party/packages/mustache_template/CHANGELOG.md
@@ -3,8 +3,6 @@
 * Adopts `code-excerpt` for the README's Dart snippets so they're validated
   against compilable, analyzed source (fixes an invalid snippet and a
   copy-pasted duplicate example that had gone unnoticed).
-* Removes the `exempt_from_excerpts` CI opt-out now that the README is
-  excerpt-backed.
 
 ## 2.0.5
 

--- a/third_party/packages/mustache_template/README.md
+++ b/third_party/packages/mustache_template/README.md
@@ -1,3 +1,5 @@
+<?code-excerpt path-base="example/lib"?>
+
 # Mustache templates
 
 A Dart library to parse and render [mustache templates](https://mustache.github.io/).
@@ -7,29 +9,27 @@ See the [mustache manual](https://mustache.github.io/mustache.5.html) for detail
 This library passes all [mustache specification](https://github.com/mustache/spec/tree/master/specs) tests.
 
 ## Example usage
+
+<?code-excerpt "readme_excerpts.dart (BasicUsage)"?>
 ```dart
-import 'package:mustache_template/mustache_template.dart';
+  final source = '''
+{{# names }}
+  <div>{{ lastname }}, {{ firstname }}</div>
+{{/ names }}
+{{^ names }}
+  <div>No names.</div>
+{{/ names }}
+{{! I am a comment. }}
+''';
 
-main() {
-	var source = '''
-	  {{# names }}
-            <div>{{ lastname }}, {{ firstname }}</div>
-	  {{/ names }}
-	  {{^ names }}
-	    <div>No names.</div>
-	  {{/ names }}
-	  {{! I am a comment. }}
-	''';
+  final template = Template(source, name: 'template-filename.html');
 
-	var template = Template(source, name: 'template-filename.html');
-
-	var output = template.renderString({'names': [
-		{'firstname': 'Greg', 'lastname': 'Lowe'},
-		{'firstname': 'Bob', 'lastname': 'Johnson'}
-	]});
-
-	print(output);
-}
+  final output = template.renderString(<String, Object>{
+    'names': <Map<String, String>>[
+      <String, String>{'firstname': 'Greg', 'lastname': 'Lowe'},
+      <String, String>{'firstname': 'Bob', 'lastname': 'Johnson'},
+    ],
+  });
 ```
 
 A template is parsed when it is created, after parsing it can be rendered any number of times with different values. A TemplateException is thrown if there is a problem parsing or rendering the template.
@@ -53,65 +53,72 @@ By default all output from `{{variable}}` tags is html escaped, this behaviour c
 
 ## Nested paths
 
+<?code-excerpt "readme_excerpts.dart (NestedPaths)"?>
 ```dart
-  var t = Template('{{ author.name }}');
-  var output = template.renderString({'author': {'name': 'Greg Lowe'}});
+final template = Template('{{ author.name }}');
+final output = template.renderString(<String, Object>{
+  'author': <String, String>{'name': 'Greg Lowe'},
+});
 ```
 
 ## Partials - example usage
 
+<?code-excerpt "readme_excerpts.dart (Partials)"?>
 ```dart
+final partial = Template('{{ foo }}', name: 'partial');
 
-var partial = Template('{{ foo }}', name: 'partial');
+Template? resolver(String name) {
+  if (name == 'partial-name') {
+    // Name of partial tag.
+    return partial;
+  }
+  return null;
+}
 
-var resolver = (String name) {
-   if (name == 'partial-name') { // Name of partial tag.
-     return partial;
-   }
-};
+final template = Template('{{> partial-name }}', partialResolver: resolver);
 
-var t = Template('{{> partial-name }}', partialResolver: resolver);
-
-var output = t.renderString({'foo': 'bar'}); // bar
-
+final output = template.renderString(<String, String>{'foo': 'bar'}); // bar
 ```
 
 ## Lambdas - example usage
 
+<?code-excerpt "readme_excerpts.dart (LambdaReturningValue)"?>
 ```dart
-var t = Template('{{# foo }}');
-var lambda = (_) => 'bar';
-t.renderString({'foo': lambda}); // bar
+final template = Template('{{# foo }}inner{{/ foo }}');
+Object lambda(Object? _) => 'bar';
+final output = template.renderString(<String, Object>{'foo': lambda}); // bar
 ```
 
+<?code-excerpt "readme_excerpts.dart (LambdaHidingSection)"?>
 ```dart
-var t = Template('{{# foo }}hidden{{/ foo }}');
-var lambda = (_) => 'shown';
-t.renderString('foo': lambda); // shown
+final template = Template('{{# foo }}hidden{{/ foo }}');
+Object lambda(Object? _) => 'shown';
+final output = template.renderString(<String, Object>{'foo': lambda}); // shown
 ```
 
+<?code-excerpt "readme_excerpts.dart (LambdaWithContext)"?>
 ```dart
-var t = Template('{{# foo }}oi{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-t.renderString({'foo': lambda}); // <b>OI</b>
+final template = Template('{{# foo }}oi{{/ foo }}');
+Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+final output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
 ```
 
+<?code-excerpt "readme_excerpts.dart (LambdaWithContextAndVariables)"?>
 ```dart
-var t = Template('{{# foo }}{{bar}}{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
-```
-
-```dart
-var t = Template('{{# foo }}{{bar}}{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+final template = Template('{{# foo }}{{bar}}{{/ foo }}');
+Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+final output = template.renderString(<String, Object>{'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
 ```
 
 In the following example `LambdaContext.renderSource(source)` re-parses the source string in the current context, this is the default behaviour in many mustache implementations. Since re-parsing the content is slow, and often not required, this library makes this step optional.
 
+<?code-excerpt "readme_excerpts.dart (LambdaReparsingSource)"?>
 ```dart
-var t = Template('{{# foo }}{{bar}}{{/ foo }}');
-var lambda = (LambdaContext ctx) => ctx.renderSource(ctx.source + ' {{cmd}}');
-t.renderString({'foo': lambda, 'bar': 'pub', 'cmd': 'build'}); // pub build
+final template = Template('{{# foo }}{{bar}}{{/ foo }}');
+Object lambda(LambdaContext ctx) => ctx.renderSource('${ctx.source} {{cmd}}');
+final output = template.renderString(<String, Object>{
+  'foo': lambda,
+  'bar': 'pub',
+  'cmd': 'build',
+}); // pub build
 ```

--- a/third_party/packages/mustache_template/README.md
+++ b/third_party/packages/mustache_template/README.md
@@ -10,9 +10,9 @@ This library passes all [mustache specification](https://github.com/mustache/spe
 
 ## Example usage
 
-<?code-excerpt "readme_excerpts.dart (BasicUsage)"?>
+<?code-excerpt "main.dart (BasicUsage)"?>
 ```dart
-  final source = '''
+  const source = '''
 {{# names }}
   <div>{{ lastname }}, {{ firstname }}</div>
 {{/ names }}
@@ -24,7 +24,7 @@ This library passes all [mustache specification](https://github.com/mustache/spe
 
   final template = Template(source, name: 'template-filename.html');
 
-  final output = template.renderString(<String, Object>{
+  final String output = template.renderString(<String, Object>{
     'names': <Map<String, String>>[
       <String, String>{'firstname': 'Greg', 'lastname': 'Lowe'},
       <String, String>{'firstname': 'Bob', 'lastname': 'Johnson'},
@@ -53,17 +53,17 @@ By default all output from `{{variable}}` tags is html escaped, this behaviour c
 
 ## Nested paths
 
-<?code-excerpt "readme_excerpts.dart (NestedPaths)"?>
+<?code-excerpt "main.dart (NestedPaths)"?>
 ```dart
 final template = Template('{{ author.name }}');
-final output = template.renderString(<String, Object>{
+final String output = template.renderString(<String, Object>{
   'author': <String, String>{'name': 'Greg Lowe'},
 });
 ```
 
 ## Partials - example usage
 
-<?code-excerpt "readme_excerpts.dart (Partials)"?>
+<?code-excerpt "main.dart (Partials)"?>
 ```dart
 final partial = Template('{{ foo }}', name: 'partial');
 
@@ -77,46 +77,49 @@ Template? resolver(String name) {
 
 final template = Template('{{> partial-name }}', partialResolver: resolver);
 
-final output = template.renderString(<String, String>{'foo': 'bar'}); // bar
+final String output = template.renderString(<String, String>{'foo': 'bar'}); // bar
 ```
 
 ## Lambdas - example usage
 
-<?code-excerpt "readme_excerpts.dart (LambdaReturningValue)"?>
+<?code-excerpt "main.dart (LambdaReturningValue)"?>
 ```dart
 final template = Template('{{# foo }}inner{{/ foo }}');
 Object lambda(Object? _) => 'bar';
-final output = template.renderString(<String, Object>{'foo': lambda}); // bar
+final String output = template.renderString(<String, Object>{'foo': lambda}); // bar
 ```
 
-<?code-excerpt "readme_excerpts.dart (LambdaHidingSection)"?>
+<?code-excerpt "main.dart (LambdaHidingSection)"?>
 ```dart
 final template = Template('{{# foo }}hidden{{/ foo }}');
 Object lambda(Object? _) => 'shown';
-final output = template.renderString(<String, Object>{'foo': lambda}); // shown
+final String output = template.renderString(<String, Object>{'foo': lambda}); // shown
 ```
 
-<?code-excerpt "readme_excerpts.dart (LambdaWithContext)"?>
+<?code-excerpt "main.dart (LambdaWithContext)"?>
 ```dart
 final template = Template('{{# foo }}oi{{/ foo }}');
 Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-final output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
+final String output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
 ```
 
-<?code-excerpt "readme_excerpts.dart (LambdaWithContextAndVariables)"?>
+<?code-excerpt "main.dart (LambdaWithContextAndVariables)"?>
 ```dart
 final template = Template('{{# foo }}{{bar}}{{/ foo }}');
 Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-final output = template.renderString(<String, Object>{'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+final String output = template.renderString(<String, Object>{
+  'foo': lambda,
+  'bar': 'pub',
+}); // <b>PUB</b>
 ```
 
 In the following example `LambdaContext.renderSource(source)` re-parses the source string in the current context, this is the default behaviour in many mustache implementations. Since re-parsing the content is slow, and often not required, this library makes this step optional.
 
-<?code-excerpt "readme_excerpts.dart (LambdaReparsingSource)"?>
+<?code-excerpt "main.dart (LambdaReparsingSource)"?>
 ```dart
 final template = Template('{{# foo }}{{bar}}{{/ foo }}');
 Object lambda(LambdaContext ctx) => ctx.renderSource('${ctx.source} {{cmd}}');
-final output = template.renderString(<String, Object>{
+final String output = template.renderString(<String, Object>{
   'foo': lambda,
   'bar': 'pub',
   'cmd': 'build',

--- a/third_party/packages/mustache_template/ci_config.yaml
+++ b/third_party/packages/mustache_template/ci_config.yaml
@@ -1,2 +1,0 @@
-# TODO(stuartmorgan): Remove this; see https://github.com/flutter/flutter/issues/102679
-exempt_from_excerpts: true

--- a/third_party/packages/mustache_template/example/lib/main.dart
+++ b/third_party/packages/mustache_template/example/lib/main.dart
@@ -2,9 +2,9 @@
 
 import 'package:mustache_template/mustache_template.dart';
 
-void basicUsage() {
+void _basicUsage() {
   // #docregion BasicUsage
-  final source = '''
+  const source = '''
 {{# names }}
   <div>{{ lastname }}, {{ firstname }}</div>
 {{/ names }}
@@ -16,7 +16,7 @@ void basicUsage() {
 
   final template = Template(source, name: 'template-filename.html');
 
-  final output = template.renderString(<String, Object>{
+  final String output = template.renderString(<String, Object>{
     'names': <Map<String, String>>[
       <String, String>{'firstname': 'Greg', 'lastname': 'Lowe'},
       <String, String>{'firstname': 'Bob', 'lastname': 'Johnson'},
@@ -26,17 +26,17 @@ void basicUsage() {
   print(output);
 }
 
-void nestedPaths() {
+void _nestedPaths() {
   // #docregion NestedPaths
   final template = Template('{{ author.name }}');
-  final output = template.renderString(<String, Object>{
+  final String output = template.renderString(<String, Object>{
     'author': <String, String>{'name': 'Greg Lowe'},
   });
   // #enddocregion NestedPaths
   print(output);
 }
 
-void partials() {
+void _partials() {
   // #docregion Partials
   final partial = Template('{{ foo }}', name: 'partial');
 
@@ -50,52 +50,55 @@ void partials() {
 
   final template = Template('{{> partial-name }}', partialResolver: resolver);
 
-  final output = template.renderString(<String, String>{'foo': 'bar'}); // bar
+  final String output = template.renderString(<String, String>{'foo': 'bar'}); // bar
   // #enddocregion Partials
   print(output);
 }
 
-void lambdaReturningValue() {
+void _lambdaReturningValue() {
   // #docregion LambdaReturningValue
   final template = Template('{{# foo }}inner{{/ foo }}');
   Object lambda(Object? _) => 'bar';
-  final output = template.renderString(<String, Object>{'foo': lambda}); // bar
+  final String output = template.renderString(<String, Object>{'foo': lambda}); // bar
   // #enddocregion LambdaReturningValue
   print(output);
 }
 
-void lambdaHidingSection() {
+void _lambdaHidingSection() {
   // #docregion LambdaHidingSection
   final template = Template('{{# foo }}hidden{{/ foo }}');
   Object lambda(Object? _) => 'shown';
-  final output = template.renderString(<String, Object>{'foo': lambda}); // shown
+  final String output = template.renderString(<String, Object>{'foo': lambda}); // shown
   // #enddocregion LambdaHidingSection
   print(output);
 }
 
-void lambdaWithContext() {
+void _lambdaWithContext() {
   // #docregion LambdaWithContext
   final template = Template('{{# foo }}oi{{/ foo }}');
   Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-  final output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
+  final String output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
   // #enddocregion LambdaWithContext
   print(output);
 }
 
-void lambdaWithContextAndVariables() {
+void _lambdaWithContextAndVariables() {
   // #docregion LambdaWithContextAndVariables
   final template = Template('{{# foo }}{{bar}}{{/ foo }}');
   Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
-  final output = template.renderString(<String, Object>{'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+  final String output = template.renderString(<String, Object>{
+    'foo': lambda,
+    'bar': 'pub',
+  }); // <b>PUB</b>
   // #enddocregion LambdaWithContextAndVariables
   print(output);
 }
 
-void lambdaReparsingSource() {
+void _lambdaReparsingSource() {
   // #docregion LambdaReparsingSource
   final template = Template('{{# foo }}{{bar}}{{/ foo }}');
   Object lambda(LambdaContext ctx) => ctx.renderSource('${ctx.source} {{cmd}}');
-  final output = template.renderString(<String, Object>{
+  final String output = template.renderString(<String, Object>{
     'foo': lambda,
     'bar': 'pub',
     'cmd': 'build',
@@ -105,12 +108,12 @@ void lambdaReparsingSource() {
 }
 
 void main() {
-  basicUsage();
-  nestedPaths();
-  partials();
-  lambdaReturningValue();
-  lambdaHidingSection();
-  lambdaWithContext();
-  lambdaWithContextAndVariables();
-  lambdaReparsingSource();
+  _basicUsage();
+  _nestedPaths();
+  _partials();
+  _lambdaReturningValue();
+  _lambdaHidingSection();
+  _lambdaWithContext();
+  _lambdaWithContextAndVariables();
+  _lambdaReparsingSource();
 }

--- a/third_party/packages/mustache_template/example/lib/readme_excerpts.dart
+++ b/third_party/packages/mustache_template/example/lib/readme_excerpts.dart
@@ -1,0 +1,116 @@
+// ignore_for_file: avoid_print
+
+import 'package:mustache_template/mustache_template.dart';
+
+void basicUsage() {
+  // #docregion BasicUsage
+  final source = '''
+{{# names }}
+  <div>{{ lastname }}, {{ firstname }}</div>
+{{/ names }}
+{{^ names }}
+  <div>No names.</div>
+{{/ names }}
+{{! I am a comment. }}
+''';
+
+  final template = Template(source, name: 'template-filename.html');
+
+  final output = template.renderString(<String, Object>{
+    'names': <Map<String, String>>[
+      <String, String>{'firstname': 'Greg', 'lastname': 'Lowe'},
+      <String, String>{'firstname': 'Bob', 'lastname': 'Johnson'},
+    ],
+  });
+  // #enddocregion BasicUsage
+  print(output);
+}
+
+void nestedPaths() {
+  // #docregion NestedPaths
+  final template = Template('{{ author.name }}');
+  final output = template.renderString(<String, Object>{
+    'author': <String, String>{'name': 'Greg Lowe'},
+  });
+  // #enddocregion NestedPaths
+  print(output);
+}
+
+void partials() {
+  // #docregion Partials
+  final partial = Template('{{ foo }}', name: 'partial');
+
+  Template? resolver(String name) {
+    if (name == 'partial-name') {
+      // Name of partial tag.
+      return partial;
+    }
+    return null;
+  }
+
+  final template = Template('{{> partial-name }}', partialResolver: resolver);
+
+  final output = template.renderString(<String, String>{'foo': 'bar'}); // bar
+  // #enddocregion Partials
+  print(output);
+}
+
+void lambdaReturningValue() {
+  // #docregion LambdaReturningValue
+  final template = Template('{{# foo }}inner{{/ foo }}');
+  Object lambda(Object? _) => 'bar';
+  final output = template.renderString(<String, Object>{'foo': lambda}); // bar
+  // #enddocregion LambdaReturningValue
+  print(output);
+}
+
+void lambdaHidingSection() {
+  // #docregion LambdaHidingSection
+  final template = Template('{{# foo }}hidden{{/ foo }}');
+  Object lambda(Object? _) => 'shown';
+  final output = template.renderString(<String, Object>{'foo': lambda}); // shown
+  // #enddocregion LambdaHidingSection
+  print(output);
+}
+
+void lambdaWithContext() {
+  // #docregion LambdaWithContext
+  final template = Template('{{# foo }}oi{{/ foo }}');
+  Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+  final output = template.renderString(<String, Object>{'foo': lambda}); // <b>OI</b>
+  // #enddocregion LambdaWithContext
+  print(output);
+}
+
+void lambdaWithContextAndVariables() {
+  // #docregion LambdaWithContextAndVariables
+  final template = Template('{{# foo }}{{bar}}{{/ foo }}');
+  Object lambda(LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+  final output = template.renderString(<String, Object>{'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+  // #enddocregion LambdaWithContextAndVariables
+  print(output);
+}
+
+void lambdaReparsingSource() {
+  // #docregion LambdaReparsingSource
+  final template = Template('{{# foo }}{{bar}}{{/ foo }}');
+  Object lambda(LambdaContext ctx) => ctx.renderSource('${ctx.source} {{cmd}}');
+  final output = template.renderString(<String, Object>{
+    'foo': lambda,
+    'bar': 'pub',
+    'cmd': 'build',
+  }); // pub build
+  // #enddocregion LambdaReparsingSource
+  print(output);
+}
+
+void main() {
+  basicUsage();
+  nestedPaths();
+  partials();
+  lambdaReturningValue();
+  lambdaHidingSection();
+  lambdaWithContext();
+  lambdaWithContextAndVariables();
+  lambdaReparsingSource();
+}

--- a/third_party/packages/mustache_template/example/pubspec.yaml
+++ b/third_party/packages/mustache_template/example/pubspec.yaml
@@ -1,0 +1,10 @@
+name: mustache_template_example
+description: Example code for the mustache_template package.
+publish_to: none
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  mustache_template:
+    path: ../

--- a/third_party/packages/mustache_template/pubspec.yaml
+++ b/third_party/packages/mustache_template/pubspec.yaml
@@ -2,7 +2,7 @@ name: mustache_template
 description: A templating library that implements the Mustache template specification
 repository: https://github.com/flutter/core-packages/tree/main/third_party/packages/mustache_template
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+mustache_template%22
-version: 2.0.5
+version: 2.0.6
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Replaces the hand-written Dart snippets in `mustache_template`'s README with `<?code-excerpt?>` pragmas backed by a new `example/lib/readme_excerpts.dart`, so every snippet is validated against compilable, analyzed source instead of free-hand text (`dart pub global run flutter_plugin_tools update-excerpts` / `validate` both pass clean).

This surfaced two pre-existing doc bugs:
- `Template('{{# foo }}')` in the first lambda example had no closing tag, so it threw a parse error the moment it was actually executed.
- The two `<b>PUB</b>` lambda examples were an exact copy-pasted duplicate; the duplicate is removed.

Also removes `ci_config.yaml`, whose only purpose was opting the package out of excerpt validation (see #102679-style TODO in the file) — no longer needed now that the README is excerpt-backed.

**Note on overlap:** flutter/flutter#183936 already has two other open PRs addressing it — #23 and #36. This PR was written independently and additionally removes the `ci_config.yaml` exemption, which neither of those does. Happy to have maintainers close this in favor of one of those if that's preferred; flagging here so reviewer time isn't wasted on duplicate review.

Fixes https://github.com/flutter/flutter/issues/183936

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [Flutter style guide] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[vector_math]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

This PR only touches the README, CHANGELOG, an example app, and a CI opt-out file — no package source changed, so it falls under the documentation/example test exemption. The new `example/lib/readme_excerpts.dart` is exercised directly (`dart run`) as part of verifying this change, and every existing test in the package (`dart test`, 252 tests) still passes.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/core-packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter style guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

FPOCTSMP-8
